### PR TITLE
Bug fix. for Bucket.GetRootBucketNames()

### DIFF
--- a/mbuckets.go
+++ b/mbuckets.go
@@ -484,10 +484,11 @@ func (b *Bucket) GetRootBucketNames() ([][]byte, error) {
 
 	bucketNames := make([][]byte, 0, len(names))
 	for _, name := range names {
-		bucketName := bytes.NewBuffer(b.Name)
-		bucketName.Write(b.Separator)
-		bucketName.Write(name)
-		bucketNames = append(bucketNames, bucketName.Bytes())
+		bucketName := []byte{}
+		bucketName = append(bucketName, b.Name...)
+		bucketName = append(bucketName, b.Separator...)
+		bucketName = append(bucketName, name...)
+		bucketNames = append(bucketNames, bucketName)
 	}
 
 	return bucketNames, nil


### PR DESCRIPTION
The bucketNames should be:

logger/filters/color
logger/filters/file
logger/filters/socket

When using `bytes.NewBuffer`, the result is:

logger/filters/socke
logger/filters/sock
logger/filters/socket

The `bytes.NewBuffer` using the pointer of b.Name? I am not sure where is the problem.

Setting `bucketName`  as []byte, every thing is fine.